### PR TITLE
Refactor DIContainer to support circular dependency resolution

### DIFF
--- a/src/test/java/core/ServerTest.java
+++ b/src/test/java/core/ServerTest.java
@@ -7,7 +7,6 @@ import com.sun.net.httpserver.HttpServer;
 import io.ember.core.*;
 import io.ember.enums.HttpMethod;
 import io.ember.enums.HttpStatusCode;
-import io.ember.examples.ServiceExample.middleware.CustomMiddleware;
 import io.ember.exceptions.HttpException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,7 +46,7 @@ class ServerTest {
 
     @BeforeEach
     void setUp() {
-        middleware = List.of(new CustomMiddleware());
+        middleware = List.of();
         server = new Server(router, middleware);
         handlerCaptor = ArgumentCaptor.forClass(HttpHandler.class);
 


### PR DESCRIPTION
Enhanced the DIContainer to properly handle circular dependencies using partially initialized instances. Added test cases to verify resolution of complex circular dependency chains and services with final fields or no public constructors. Removed unused middleware in ServerTest for improved clarity.